### PR TITLE
Add Hex support

### DIFF
--- a/bigint.h
+++ b/bigint.h
@@ -459,6 +459,14 @@ namespace BigInt {
         if (s.empty())
             return false;
 
+        // Check for leading negative sign
+        if (s[0] == '-') {
+            if (s.length() == 1) return false;
+            // Recursively validate the rest as a positive bigint
+            // Note: leading zeros check still applies to the magnitude
+            return is_bigint(s.substr(1));
+        }
+
         // Check for hex string "0x..."
         if (s.length() > 2 && s[0] == '0' && s[1] == 'x') {
             return s.find_first_not_of("0123456789abcdefABCDEF", 2) == std::string::npos;
@@ -468,9 +476,6 @@ namespace BigInt {
         if (s.length() > 1 && s[0] == '0')
             return false;
 
-        if (s[0] == '-') {
-            return s.find_first_not_of("0123456789", 1) == std::string::npos;
-        }
         return s.find_first_not_of("0123456789", 0) == std::string::npos;
     }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -121,6 +121,7 @@ TEST(Test_BigInt, Invalid_Tests) {
 
 TEST(Test_BigInt, Creation_Tests) {
     int my_int = 100;
+    unsigned int hex_int = 0xDEADBEEF;
     long my_long = 100;
     long long my_longlong = 100;
     long long my_longlong2 = LLONG_MAX;
@@ -131,9 +132,12 @@ TEST(Test_BigInt, Creation_Tests) {
     std::string my_string = "100";
     std::string my_string3 = "-9223372036854775808";
     std::string my_string4 = "-9223372036854775809";
+    std::string hex_string = "0xDEADBEEF0FF1CEF0CACC1A";
 
     EXPECT_EQ(bigint(my_int), 100);
     EXPECT_EQ(bigint(-my_int), -100);
+
+    EXPECT_EQ(bigint(hex_int), 3735928559);
 
     EXPECT_EQ(bigint(my_long), 100);
     EXPECT_EQ(bigint(-my_long), -100);
@@ -153,6 +157,7 @@ TEST(Test_BigInt, Creation_Tests) {
     EXPECT_EQ(bigint(my_string), "100");
     EXPECT_EQ(bigint(my_string3), "-9223372036854775808");
     EXPECT_EQ(bigint(my_string4), "-9223372036854775809");
+    EXPECT_EQ(bigint(hex_string), "269202023463611101042363418");
 }
 
 TEST(Test_BigInt, Unary_Tests) {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -99,8 +99,10 @@ class BigInt_ModParamTest : public ::testing::TestWithParam<TestCase>{};
 
 TEST(Test_BigInt, Invalid_Tests) {
     EXPECT_THROW(bigint('a'), std::runtime_error);
+    EXPECT_THROW(bigint('z'), std::runtime_error);
     EXPECT_THROW(bigint(static_cast<char>(0)), std::runtime_error);
     EXPECT_THROW(bigint(static_cast<char>(-1)), std::runtime_error);
+    EXPECT_THROW(bigint(static_cast<char>(99)), std::runtime_error);
     EXPECT_THROW(bigint("a"), std::runtime_error);
     EXPECT_THROW(bigint("?"), std::runtime_error);
     EXPECT_THROW(bigint(""), std::runtime_error);
@@ -122,6 +124,7 @@ TEST(Test_BigInt, Invalid_Tests) {
 TEST(Test_BigInt, Creation_Tests) {
     int my_int = 100;
     unsigned int hex_int = 0xDEADBEEF;
+    int neg_hex_int = -0xBEEF;
     long my_long = 100;
     long long my_longlong = 100;
     long long my_longlong2 = LLONG_MAX;
@@ -133,11 +136,13 @@ TEST(Test_BigInt, Creation_Tests) {
     std::string my_string3 = "-9223372036854775808";
     std::string my_string4 = "-9223372036854775809";
     std::string hex_string = "0xDEADBEEF0FF1CEF0CACC1A";
+    std::string neg_hex_string = "-0xBEEF";
 
     EXPECT_EQ(bigint(my_int), 100);
     EXPECT_EQ(bigint(-my_int), -100);
 
     EXPECT_EQ(bigint(hex_int), 3735928559);
+    EXPECT_EQ(bigint(neg_hex_int), -48879);
 
     EXPECT_EQ(bigint(my_long), 100);
     EXPECT_EQ(bigint(-my_long), -100);
@@ -157,7 +162,9 @@ TEST(Test_BigInt, Creation_Tests) {
     EXPECT_EQ(bigint(my_string), "100");
     EXPECT_EQ(bigint(my_string3), "-9223372036854775808");
     EXPECT_EQ(bigint(my_string4), "-9223372036854775809");
+
     EXPECT_EQ(bigint(hex_string), "269202023463611101042363418");
+    EXPECT_EQ(bigint(neg_hex_string), "-48879");
 }
 
 TEST(Test_BigInt, Unary_Tests) {


### PR DESCRIPTION
Add Hex support for strings. Note: Signed integers represented as hex values could be converted to 2's compliment form, causing issues. Use unsigned int when converting raw hex values, or use signs within a string.